### PR TITLE
Add SHOW_RES toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Dieses Skript ruft regelmäßig Noten aus dem Fux Elternportal ab und sendet neu
    DISCORD_TOKEN=<Bot-Token>
    DISCORD_CHANNEL_ID=<Channel-ID>
    INTERVAL_MINUTES=5
+   # Set SHOW_RES=true to omit HTML responses from the log
+   SHOW_RES=false
    ```
 2. Installiere die Abhängigkeiten:
    ```bash

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ PASSWORD = os.getenv("PASSWORD")
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 DISCORD_CHANNEL_ID = os.getenv("DISCORD_CHANNEL_ID")
 INTERVAL_MINUTES = int(os.getenv("INTERVAL_MINUTES", "5"))
+SHOW_RES = os.getenv("SHOW_RES", "false").lower() == "true"
 
 
 def check_env():
@@ -227,11 +228,14 @@ def fetch_html():
     except Exception as e:
         logging.error(f"Login-Seite nicht erreichbar: {e}")
         return _read_local_html()
-    logging.info(
-        "Login-Seite Response (%s): %s",
-        login_page.status_code,
-        login_page.text,
-    )
+    if SHOW_RES:
+        logging.info("Login-Seite Response (%s)", login_page.status_code)
+    else:
+        logging.info(
+            "Login-Seite Response (%s): %s",
+            login_page.status_code,
+            login_page.text,
+        )
 
     soup = BeautifulSoup(login_page.text, "html.parser")
     nonce_field = soup.find("input", {"name": "_nonce"})
@@ -255,11 +259,14 @@ def fetch_html():
     except Exception as e:
         logging.error(f"Login-Request fehlgeschlagen: {e}")
         return _read_local_html()
-    logging.info(
-        "Login-POST Response (%s): %s",
-        resp.status_code,
-        resp.text,
-    )
+    if SHOW_RES:
+        logging.info("Login-POST Response (%s)", resp.status_code)
+    else:
+        logging.info(
+            "Login-POST Response (%s): %s",
+            resp.status_code,
+            resp.text,
+        )
 
     # Prüfen, ob Login erfolgreich war (Seite sollte kein Login-Formular mehr enthalten)
     if resp.status_code != 200 or 'name="user"' in resp.text:
@@ -274,11 +281,14 @@ def fetch_html():
     except Exception as e:
         logging.error(f"Fehler beim Abrufen der Notenübersicht: {e}")
         return _read_local_html()
-    logging.info(
-        "Notenübersicht Response (%s): %s",
-        grades_page.status_code,
-        grades_page.text,
-    )
+    if SHOW_RES:
+        logging.info("Notenübersicht Response (%s)", grades_page.status_code)
+    else:
+        logging.info(
+            "Notenübersicht Response (%s): %s",
+            grades_page.status_code,
+            grades_page.text,
+        )
 
     return grades_page.text
 


### PR DESCRIPTION
## Summary
- add `SHOW_RES` env var to suppress HTML response logging
- document the new variable in README

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_684c5973dbe88322829fa32b5ce1cd7d