### PR TITLE
Fix env handling for user credentials

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,32 +8,36 @@ from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 
 # Konfiguration aus .env laden
-# .env-Datei einlesen
-load_dotenv()
+# .env-Datei einlesen und vorhandene Umgebungsvariablen 
+# überschreiben, damit alte Werte nicht erhalten bleiben
+load_dotenv(override=True)
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 DISCORD_CHANNEL_ID = os.getenv("DISCORD_CHANNEL_ID")
 INTERVAL_MINUTES = int(os.getenv("INTERVAL_MINUTES", "5"))
 SHOW_RES = os.getenv("SHOW_RES", "false").lower() == "true"
 
 # Mehrere Benutzer aus der .env-Datei laden
+# Die Indizes müssen nicht lückenlos sein; vorhandene Paare werden gesammelt
 USERS = []
-i = 1
-while True:
+user_indexes = set()
+for key in os.environ:
+    m = re.match(r"USER(\d+)$", key)
+    if m:
+        user_indexes.add(int(m.group(1)))
+
+for i in sorted(user_indexes):
     name = os.getenv(f"USER{i}")
     username = os.getenv(f"USERNAME{i}")
     password = os.getenv(f"PASSWORD{i}")
     if name and username and password:
         USERS.append({"name": name, "username": username, "password": password})
-        i += 1
-    else:
-        break
 
 
 def check_env():
     """Ensure all required environment variables are present."""
     missing = []
     if not USERS:
-        missing.append("USER1/USERNAME1/PASSWORD1")
+        missing.append("USERn/USERNAMEn/PASSWORDn")
     if not DISCORD_TOKEN:
         missing.append("DISCORD_TOKEN")
     if not DISCORD_CHANNEL_ID:

--- a/tests/test_noten.py
+++ b/tests/test_noten.py
@@ -101,3 +101,19 @@ def test_new_grade_and_final(monkeypatch):
     assert "Neue Note" in sent[0]
     assert any("Zeugnisnote" in s for s in sent)
     assert len(sent) == len(messages)
+
+
+def test_sparse_user_indexes(monkeypatch):
+    monkeypatch.delenv("USER1", raising=False)
+    monkeypatch.delenv("USERNAME1", raising=False)
+    monkeypatch.delenv("PASSWORD1", raising=False)
+    monkeypatch.setenv("USER2", "Sparse")
+    monkeypatch.setenv("USERNAME2", "user2")
+    monkeypatch.setenv("PASSWORD2", "pass2")
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", "123")
+    import importlib
+    import main
+    importlib.reload(main)
+    assert len(main.USERS) == 1
+    assert main.USERS[0]["username"] == "user2"


### PR DESCRIPTION
## Summary
- reload `.env` variables with override so old values can't linger
- gather user credentials from any numeric index
- improve error message for missing user env vars
- add regression test for sparse user indexes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d51e009848322a36ad6d411b5c9bb