### PR TITLE
Fix fetch_html error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -255,7 +255,7 @@ def fetch_html(username: str, password: str, session: requests.Session | None = 
         login_page = session.get(login_url)
     except Exception as e:
         logging.error(f"Login-Seite nicht erreichbar: {e}")
-        return _read_local_html()
+        return None
     if SHOW_RES:
         logging.info(
             "Login-Seite Response (%s): %s",
@@ -287,7 +287,7 @@ def fetch_html(username: str, password: str, session: requests.Session | None = 
         resp = session.post(login_url, data=payload, allow_redirects=True)
     except Exception as e:
         logging.error(f"Login-Request fehlgeschlagen: {e}")
-        return _read_local_html()
+        return None
     if SHOW_RES:
         logging.info(
             "Login-POST Response (%s): %s",
@@ -300,7 +300,7 @@ def fetch_html(username: str, password: str, session: requests.Session | None = 
     # Prüfen, ob Login erfolgreich war (Seite sollte kein Login-Formular mehr enthalten)
     if resp.status_code != 200 or 'name="user"' in resp.text:
         logging.error("Login fehlgeschlagen – Status %s", resp.status_code)
-        return _read_local_html()
+        return None
 
     # Notenübersicht abrufen (nach erfolgreichem Login)
     try:
@@ -309,7 +309,7 @@ def fetch_html(username: str, password: str, session: requests.Session | None = 
         )
     except Exception as e:
         logging.error(f"Fehler beim Abrufen der Notenübersicht: {e}")
-        return _read_local_html()
+        return None
     if SHOW_RES:
         logging.info(
             "Notenübersicht Response (%s): %s",

--- a/tests/test_noten.py
+++ b/tests/test_noten.py
@@ -117,3 +117,16 @@ def test_sparse_user_indexes(monkeypatch):
     importlib.reload(main)
     assert len(main.USERS) == 1
     assert main.USERS[0]["username"] == "user2"
+
+
+def test_fetch_html_returns_none_on_error(monkeypatch):
+    main = setup_env(monkeypatch)
+
+    def fail_get(self, *args, **kwargs):
+        raise requests.RequestException("fail")
+
+    monkeypatch.setattr(requests.Session, "get", fail_get)
+
+    session = requests.Session()
+    html = main.fetch_html("u", "p", session=session)
+    assert html is None


### PR DESCRIPTION
## Summary
- return `None` on network failures in `fetch_html`
- add regression test for `fetch_html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d5da2e4c08322b82605ce8659a265