### PR TITLE
Add SHOW_HTTPS request logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Dieses Skript ruft regelmäßig Noten aus dem Fux Elternportal ab und sendet neu
     INTERVAL_MINUTES=5
     # Set SHOW_RES=true to include HTML responses in the log
     SHOW_RES=false
+    # Set SHOW_HTTPS=true to log HTTP requests with credentials
+    SHOW_HTTPS=false
    ```
 2. Installiere die Abhängigkeiten:
    ```bash

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 DISCORD_CHANNEL_ID = os.getenv("DISCORD_CHANNEL_ID")
 INTERVAL_MINUTES = int(os.getenv("INTERVAL_MINUTES", "5"))
 SHOW_RES = os.getenv("SHOW_RES", "false").lower() == "true"
+SHOW_HTTPS = os.getenv("SHOW_HTTPS", "false").lower() == "true"
 
 # Mehrere Benutzer aus der .env-Datei laden
 # Die Indizes müssen nicht lückenlos sein; vorhandene Paare werden gesammelt
@@ -252,6 +253,8 @@ def fetch_html(username: str, password: str, session: requests.Session | None = 
         }
     )
     try:
+        if SHOW_HTTPS:
+            logging.info("HTTP GET %s (username=%s)", login_url, username)
         login_page = session.get(login_url)
     except Exception as e:
         logging.error(f"Login-Seite nicht erreichbar: {e}")
@@ -284,6 +287,13 @@ def fetch_html(username: str, password: str, session: requests.Session | None = 
 
     # Schritt 2: Login-POST mit allen erforderlichen Feldern
     try:
+        if SHOW_HTTPS:
+            logging.info(
+                "HTTP POST %s (username=%s, password=%s)",
+                login_url,
+                username,
+                password,
+            )
         resp = session.post(login_url, data=payload, allow_redirects=True)
     except Exception as e:
         logging.error(f"Login-Request fehlgeschlagen: {e}")
@@ -304,9 +314,14 @@ def fetch_html(username: str, password: str, session: requests.Session | None = 
 
     # Notenübersicht abrufen (nach erfolgreichem Login)
     try:
-        grades_page = session.get(
-            "https://100308.fuxnoten.online/webinfo/account/"
-        )
+        grades_url = "https://100308.fuxnoten.online/webinfo/account/"
+        if SHOW_HTTPS:
+            logging.info(
+                "HTTP GET %s (username=%s)",
+                grades_url,
+                username,
+            )
+        grades_page = session.get(grades_url)
     except Exception as e:
         logging.error(f"Fehler beim Abrufen der Notenübersicht: {e}")
         return None


### PR DESCRIPTION
## Summary
- add environment option `SHOW_HTTPS` for debugging
- log HTTP requests when `SHOW_HTTPS=true`
- document the new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d6768735c8322aac28da6caf82e9c