### PR TITLE
Add DEBUG_LOCAL mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Dieses Skript ruft regelmäßig Noten aus dem Fux Elternportal ab und sendet neu
     SHOW_RES=false
     # Set SHOW_HTTPS=true to log HTTP requests with credentials
     SHOW_HTTPS=false
+    # Fetch grades from a local web server instead of logging in
+    # USERNAMEn and PASSWORDn become optional when enabled
+    DEBUG_LOCAL=false
    ```
 2. Installiere die Abhängigkeiten:
    ```bash
@@ -31,6 +34,8 @@ Dieses Skript ruft regelmäßig Noten aus dem Fux Elternportal ab und sendet neu
    ```bash
    python3 main.py
    ```
+   Ist `DEBUG_LOCAL=true` gesetzt, ruft das Skript die Datei
+   `http://localhost:8000/index.html` ab und verzichtet auf den Login.
 
 Das Skript legt f\xC3\xBCr jeden Benutzer eine Datei `grades_<Name>.json` mit den aktuellen Noten an und protokolliert Ereignisse in `noten_checker.log`.
 

--- a/tests/test_noten.py
+++ b/tests/test_noten.py
@@ -130,3 +130,35 @@ def test_fetch_html_returns_none_on_error(monkeypatch):
     session = requests.Session()
     html = main.fetch_html("u", "p", session=session)
     assert html is None
+
+
+def test_debug_local_no_credentials(monkeypatch):
+    monkeypatch.setenv("DEBUG_LOCAL", "true")
+    monkeypatch.setenv("USER1", "Debug")
+    monkeypatch.delenv("USERNAME1", raising=False)
+    monkeypatch.delenv("PASSWORD1", raising=False)
+    monkeypatch.delenv("USER2", raising=False)
+    monkeypatch.delenv("USERNAME2", raising=False)
+    monkeypatch.delenv("PASSWORD2", raising=False)
+    monkeypatch.setenv("DISCORD_TOKEN", "t")
+    monkeypatch.setenv("DISCORD_CHANNEL_ID", "1")
+
+    import importlib
+    import main
+    importlib.reload(main)
+
+    assert len(main.USERS) == 1
+    assert main.USERS[0]["name"] == "Debug"
+
+
+def test_fetch_html_debug_local(monkeypatch):
+    monkeypatch.setenv("DEBUG_LOCAL", "true")
+    main = setup_env(monkeypatch)
+    server, thread = start_server(os.getcwd())
+    try:
+        session = requests.Session()
+        data = main.fetch_html("", "", session=session)
+    finally:
+        server.shutdown()
+        thread.join()
+    assert "Deutsch" in data["subjects"]


### PR DESCRIPTION
## Summary
- support a DEBUG_LOCAL mode that pulls `index.html` from localhost and skips login
- allow creating users without credentials when DEBUG_LOCAL=true
- document new environment flag in README
- test login bypass and missing credentials handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d7516a4d08322878f0dff75112954