### PR TITLE
Handle exam grades separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Dieses Skript ruft regelmäßig Noten aus dem Fux Elternportal ab und sendet neu
    Ist `DEBUG_LOCAL=true` gesetzt, ruft das Skript die Datei
    `http://localhost:8000/index.html` ab und verzichtet auf den Login.
 
-Das Skript legt f\xC3\xBCr jeden Benutzer eine Datei `grades_<Name>.json` mit den aktuellen Noten an und protokolliert Ereignisse in `noten_checker.log`.
+ Das Skript legt f\xC3\xBCr jeden Benutzer eine Datei `grades_<Name>.json` mit den aktuellen Noten an und protokolliert Ereignisse in `noten_checker.log`.
+ Neue Klassenarbeitsnoten werden gesondert mit dem Hinweis "Klassenarbeitsnote" in Discord gemeldet.
 
 ## Tests
 

--- a/main.py
+++ b/main.py
@@ -378,12 +378,13 @@ if __name__ == "__main__":
             old_info_all = old_data.get(user["name"], {})
             for subject, info in data.get("subjects", {}).items():
                 old_info = old_info_all.get("subjects", {}).get(subject, {})
-                for sem in ["H1Grades", "H2Grades"]:
+                for sem in ["H1Grades", "H2Grades", "H1Exams", "H2Exams"]:
                     new_list = info.get(sem, [])
                     old_list = old_info.get(sem, [])
                     for grade in new_list[len(old_list):]:
+                        prefix = "Klassenarbeitsnote" if sem.endswith("Exams") else "Note"
                         messages.append(
-                            f"[{user['name']}] Neue Note in {subject} ({sem[:2]}): {grade}"
+                            f"[{user['name']}] Neue {prefix} in {subject} ({sem[:2]}): {grade}"
                         )
                 new_final = info.get("FinalGrade")
                 if new_final is not None and new_final != old_info.get("FinalGrade"):


### PR DESCRIPTION
## Summary
- include exam grades when building the message list
- note class exam grades as `Klassenarbeitsnote`
- test exam notifications
- document the new behaviour in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e920c6bc083228bb3861d015ddae2