### PR TITLE
Handle exam grade duplicates

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,7 +111,14 @@ def _parse_semester_table(table):
 
         # Expect: first two entries -> class tests, last entry -> average of
         # regular grades. Everything in between are regular grades themselves.
-        tests = [v for v in values[:2] if v]
+        tests = []
+        for v in values[:2]:
+            if not v:
+                continue
+            if "," in v:
+                v = v.split(",", 1)[0]
+            if not tests or tests[-1] != v:
+                tests.append(v)
         grades = [v for v in values[2:-1] if v]
         grades_avg = None
         if values:

--- a/tests/test_noten.py
+++ b/tests/test_noten.py
@@ -189,3 +189,11 @@ def test_parse_with_stray_text(monkeypatch):
     assert len(changed["subjects"]["Deutsch"]["H1Grades"]) == len(base["subjects"]["Deutsch"]["H1Grades"]) + 1
     msgs = compute_messages({"Test": base}, {"subjects": changed["subjects"]}, "Test")
     assert any("Neue Note" in m for m in msgs)
+
+
+def test_exams_without_decimal(monkeypatch):
+    main = setup_env(monkeypatch)
+    html = open("index.html", encoding="utf-8").read()
+    data = main.parse_grades(html)
+    exams = data["subjects"]["Deutsch"]["H1Exams"]
+    assert all("," not in e for e in exams)


### PR DESCRIPTION
## Summary
- sanitize exam grades so the exported `H1Exams` list only contains integer values
- test that exam grades no longer include decimal duplicates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e93a4ddc4832295f21237633b0fcc