### PR TITLE
Aggregate grade updates per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Dieses Skript ruft regelmäßig Noten aus dem Fux Elternportal ab und sendet neu
    Ist `DEBUG_LOCAL=true` gesetzt, ruft das Skript die Datei
    `http://localhost:8000/index.html` ab und verzichtet auf den Login.
 
- Das Skript legt f\xC3\xBCr jeden Benutzer eine Datei `grades_<Name>.json` mit den aktuellen Noten an und protokolliert Ereignisse in `noten_checker.log`.
- Neue Klassenarbeitsnoten werden gesondert mit dem Hinweis "Klassenarbeitsnote" in Discord gemeldet.
+Das Skript legt f\xC3\xBCr jeden Benutzer eine Datei `grades_<Name>.json` mit den aktuellen Noten an und protokolliert Ereignisse in `noten_checker.log`.
+Neue Klassenarbeitsnoten werden gesondert mit dem Hinweis "Klassenarbeitsnote" in Discord gemeldet.
+Alle neuen Noten eines Benutzers werden zu einer einzigen Discord-Nachricht zusammengefasst.
 
 ## Tests
 

--- a/main.py
+++ b/main.py
@@ -410,19 +410,20 @@ if __name__ == "__main__":
                     "Authorization": f"Bot {DISCORD_TOKEN}",
                     "Content-Type": "application/json",
                 }
-                for msg in messages:
-                    payload = {"content": msg}
-                    try:
-                        res = requests.post(url, headers=headers, json=payload)
-                        if 200 <= res.status_code < 300:
-                            logging.info(f"Nachricht an Discord gesendet: {msg}")
-                        else:
-                            logging.error(
-                                f"Discord-API-Fehler ({res.status_code}): {res.text}"
-                            )
-                    except Exception as e:
-                        logging.error(f"Fehler beim Senden an Discord: {e}")
-                    time.sleep(1)
+                payload = {"content": "\n".join(messages)}
+                try:
+                    res = requests.post(url, headers=headers, json=payload)
+                    if 200 <= res.status_code < 300:
+                        logging.info(
+                            "Nachricht an Discord gesendet: %s", payload["content"]
+                        )
+                    else:
+                        logging.error(
+                            f"Discord-API-Fehler ({res.status_code}): {res.text}"
+                        )
+                except Exception as e:
+                    logging.error(f"Fehler beim Senden an Discord: {e}")
+                time.sleep(1)
             else:
                 logging.info(f"Keine neuen Noten gefunden f\xC3\xBCr {user['name']}.")
 

--- a/tests/test_noten.py
+++ b/tests/test_noten.py
@@ -33,7 +33,7 @@ def setup_env(monkeypatch):
 
 
 def compute_messages(old_data, new_data, user_name):
-    messages = []
+    parts = []
     show_avg = os.getenv("SHOW_YEAR_AVERAGE", "true").lower() == "true"
     old_info_all = old_data.get(user_name, {})
     for subject, info in new_data.get("subjects", {}).items():
@@ -48,14 +48,16 @@ def compute_messages(old_data, new_data, user_name):
                     avg = info.get("YearAverage")
                     if avg is not None:
                         msg += f". Damit stehst du jetzt {avg} [\"YearAverage\"]"
-                messages.append(msg)
+                parts.append(msg)
         for key, label in [("H1FinalGrade", "HJ1"), ("H2FinalGrade", "HJ2")]:
             new_final = info.get(key)
             if new_final is not None and new_final != old_info.get(key):
-                messages.append(
+                parts.append(
                     f"[{user_name}] Zeugnisnote ({label}) in {subject} steht fest: {new_final}"
                 )
-    return messages
+    if parts:
+        return ["\n".join(parts)]
+    return []
 
 
 def test_fetch_and_parse(monkeypatch):
@@ -110,8 +112,8 @@ def test_new_grade_and_final(monkeypatch):
 
     assert "Neue Note" in sent[0]
     assert "YearAverage" in sent[0]
-    assert any("Zeugnisnote" in s for s in sent)
-    assert len(sent) == len(messages)
+    assert "Zeugnisnote" in sent[0]
+    assert len(sent) == len(messages) == 1
 
 
 def test_new_exam_grade(monkeypatch):


### PR DESCRIPTION
## Summary
- aggregate grade messages per user into a single Discord message
- update tests to reflect new message aggregation
- document the new behavior in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ea20f62208322b8779ef357454093